### PR TITLE
Fix lowercase comparison which cannot be true

### DIFF
--- a/projects/deep-model/src/lib/DeepModelHandler.ts
+++ b/projects/deep-model/src/lib/DeepModelHandler.ts
@@ -40,7 +40,7 @@ export class DeepModelHandler<T> implements ProxyHandler<DeepModel<T>> {
                     this._modelSignal.update(updateFn);
                 };
             }
-            if (propStr.toLowerCase() === 'asReadonly') {
+            if (propStr.toLowerCase() === 'asreadonly') {
                 return this._modelSignal.asReadonly.bind(this._modelSignal);
             }
         }


### PR DESCRIPTION
`if (propStr.toLowerCase() == 'asReadonly') {` cannot be true - changed to `if (propStr.toLowerCase() == 'asreadonly') {`.